### PR TITLE
Handle logos when importing agencies

### DIFF
--- a/migration/v1_to_v2/configuration/exporters/agency_logo_exporter.rb
+++ b/migration/v1_to_v2/configuration/exporters/agency_logo_exporter.rb
@@ -60,20 +60,22 @@ class AgencyLogoExporter < ConfigurationExporter
   end
 
   def build_logo_file(object)
-    logo_name = "#{object['_id']}-#{object['logo_key']}"
-    File.open("#{@export_dir}/#{logo_name}", 'wb') do |f|
+    File.open("#{@export_dir}/#{logo_name(object)}", 'wb') do |f|
       f.write(object.fetch_attachment(object['logo_key']))
     end
   end
 
   def write_export_file(object)
-    logo_name = "#{object['_id']}-#{object['logo_key']}"
     @output_file.puts "\nagency = Agency.find_by(unique_id: '#{object['_id']}')"
-    @output_file.puts "logo_full = { io: File.open(\"\#{File.dirname(__FILE__)}/#{logo_name}\"), filename: '#{object['logo_key']}' }"
-    @output_file.puts "logo_icon = { io: File.open(\"\#{File.dirname(__FILE__)}/#{logo_name}\"), filename: '#{object['logo_key']}' }"
+    @output_file.puts "logo_full = { io: File.open(\"\#{File.dirname(__FILE__)}/#{logo_name(object)}\"), filename: '#{object['logo_key']}' }"
+    @output_file.puts "logo_icon = { io: File.open(\"\#{File.dirname(__FILE__)}/#{logo_name(object)}\"), filename: '#{object['logo_key']}' }"
     @output_file.puts "puts 'Adding logo to #{object['_id']}'"
     @output_file.puts 'agency.logo_full.attach(logo_full)'
     @output_file.puts 'agency.logo_icon.attach(logo_icon)'
     @output_file.puts 'agency.save!'
+  end
+
+  def logo_name(object)
+    "#{object['_id']}-#{object['logo_key'].gsub(/\s/, '-')}"
   end
 end

--- a/migration/v1_to_v2/configuration/exporters/base_config_exporter.rb
+++ b/migration/v1_to_v2/configuration/exporters/base_config_exporter.rb
@@ -43,8 +43,7 @@ class BaseConfigExporter < ConfigurationExporter
   end
 
   def configuration_hash_agency(object)
-    # TODO: handle logo
-    object.attributes.except('id', 'base_language', 'core_resource').merge(unique_id(object)).with_indifferent_access
+    object.attributes.except('id', 'base_language', 'core_resource', '_attachments').merge(unique_id(object)).with_indifferent_access
   end
 
   def configuration_hash_report(object)


### PR DESCRIPTION
We encountered 2 things when attempting to export agencies with logos from a gbv instance on 1.7:

1. `agency['logo_key']` often has spaces in the name but we were transparently passing spaces to the filenames which the ubuntu system we're deployed to doesn't like! I extracted a method for creating the `logo_name` and replaced all space related characters (`\s`) with `-`'s.

2. The spaces we're being passed through via the `base_exporter` as ruby symbol hash keys (e.g. `{ An Image Name: '...' }` which causes a syntax error. It's not apparent that we're actually using the `_attachments` key in which this issue occurred given that the `AgencyLogoExporter` exists which seems to handle that job, so I removed it!

Let me know if either of these seem a little off.